### PR TITLE
add http serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,12 @@ julia> search(ctx, "Include"; ignorecase=true, pathfilter=".*dir1.*")
  ...
 ```
 
+A HTTP service with JSON interface can be brought up with the `run_http` method. Use optional parameter `ops` to sepcify the operations that should be exposed. Additional keywords, identical to what `HTTP.serve` would accept can also be passed to this method to enable other features e.g. SSL, port reuse.
+
+```julia
+julia> using GoogleCodeSearch
+
+julia> ctx = Ctx();
+
+julia> run_http(ctx; host=ip"0.0.0.0", port=5555, ops=(:index, :search))
+```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 1.0
 BinaryProvider
+HTTP
+JSON

--- a/src/GoogleCodeSearch.jl
+++ b/src/GoogleCodeSearch.jl
@@ -1,107 +1,19 @@
 module GoogleCodeSearch
 
 using BinaryProvider
+using Sockets
+using JSON
+using HTTP
 
 import Base: show
-export Ctx, index, search, show, indices, clear_indices, paths_indexed
+export Ctx, index, search, show, indices, clear_indices, paths_indexed, run_http
 
 const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if !isfile(depsjl_path)
-    error("Blosc not installed properly, run Pkg.build(\"ZMQ\"), restart Julia and try again")
+    error("GoogleCodeSearch not installed properly, run Pkg.build(\"GoogleCodeSearch\"), restart Julia and try again")
 end
 include(depsjl_path)
-
-struct Ctx
-    store::String       # directory where to store indices
-    resolver::Any       # function to determine index filename (as subpath of store) if needed
-    lock::ReentrantLock # lock (`withenv` not task safe, could have used per index lock if it were)
-
-    function Ctx(; store::String=joinpath(homedir(), ".googlecodesearchjl"), resolver=(ctx,inpath)->joinpath(ctx.store,"index"))
-        new(store, resolver, ReentrantLock())
-    end
-end
-
-show(io::IO, ctx::Ctx) = print(io, "GoogleCodeSearch.Ctx(store=\"" * ctx.store * "\")")
-
-function readcmd_with_index(ctx::Ctx, cmd::Cmd, idxpath::String)
-    oc = lock(ctx.lock) do
-        withenv("CSEARCHINDEX"=>idxpath) do
-            OutputCollector(cmd)
-        end
-    end
-    success = wait(oc)
-    success, oc.stdout_linestream.lines, oc.stderr_linestream.lines
-end
-
-indices(ctx::Ctx) = map(x->joinpath(ctx.store,x), readdir(ctx.store))
-
-function clear_indices(ctx::Ctx)
-    for file in indices(ctx)
-        rm(file; force=true)
-    end
-    nothing
-end
-
-function paths_indexed(ctx::Ctx)
-    paths = Set{String}()
-    cmd = Cmd([cindex, "-list"])
-    for idxpath in indices(ctx)
-        success, out, err = readcmd_with_index(ctx, cmd, idxpath)
-        if success
-            for (t,m) in out
-                push!(paths, strip(m))
-            end
-        else
-            error("error reading index $idxpath")
-        end
-    end
-    paths
-end
-
-function index(ctx::Ctx, path::String)
-    cmd = Cmd([cindex, path])
-    success, out, err = readcmd_with_index(ctx, cmd, ctx.resolver(ctx,path))
-    success
-end
-
-function index(ctx::Ctx, paths::Vector{String})
-    idxpaths = Dict{String,Vector{String}}()
-    for path in paths
-        idxpath = ctx.resolver(ctx,path)
-        paths = get!(()->String[], idxpaths, idxpath)
-        push!(paths, path)
-    end
-    results = Bool[]
-    for (idxpath, paths) in idxpaths
-        cmd = Cmd(append!([cindex], paths))
-        success, out, err = readcmd_with_index(ctx, cmd, idxpath)
-        push!(results, success)
-    end
-    results
-end
-
-function search(ctx::Ctx, pattern::String; ignorecase::Bool=false, pathfilter::Union{Nothing,String}=nothing)
-    cmdparts = [csearch]
-    if pathfilter !== nothing
-        push!(cmdparts, "-f")
-        push!(cmdparts, pathfilter)
-    end
-    ignorecase && push!(cmdparts, "-i")
-    push!(cmdparts, "-n")
-    push!(cmdparts, pattern)
-    cmd = Cmd(cmdparts)
-    results = Vector{NamedTuple{(:file,:line,:text),Tuple{String,Int,String}}}()
-    for idx in readdir(ctx.store)
-        idxpath = joinpath(ctx.store, idx)
-        success, out, err = readcmd_with_index(ctx, cmd, idxpath)
-        if success
-            for (t,s) in out
-                parts = split(s, ':'; limit=3)
-                push!(results, (file=String(parts[1]), line=parse(Int,parts[2]), text=String(parts[3])))
-            end
-        end
-    end
-    results
-end
+include("codesearch.jl")
+include("server.jl")
 
 end # module

--- a/src/codesearch.jl
+++ b/src/codesearch.jl
@@ -1,0 +1,118 @@
+"""
+A context (`Ctx`) instance encapsulates the index location and provides a useful way to split indexing across multiple indices. It also holds a lock to handle it being called across tasks.
+"""
+struct Ctx
+    store::String       # directory where to store indices
+    resolver::Any       # function to determine index filename (as subpath of store) if needed
+    lock::ReentrantLock # lock (`withenv` not task safe, could have used per index lock if it were)
+
+    function Ctx(; store::String=joinpath(homedir(), ".googlecodesearchjl"), resolver=(ctx,inpath)->joinpath(ctx.store,"index"))
+        mkpath(store)
+        new(store, resolver, ReentrantLock())
+    end
+end
+
+show(io::IO, ctx::Ctx) = print(io, "GoogleCodeSearch.Ctx(store=\"" * ctx.store * "\")")
+
+function readcmd_with_index(ctx::Ctx, cmd::Cmd, idxpath::String)
+    oc = lock(ctx.lock) do
+        withenv("CSEARCHINDEX"=>idxpath) do
+            OutputCollector(cmd)
+        end
+    end
+    success = wait(oc)
+    success, oc.stdout_linestream.lines, oc.stderr_linestream.lines
+end
+
+"""
+Returns a list of index files that are being used in this context.
+"""
+indices(ctx::Ctx) = map(x->joinpath(ctx.store,x), readdir(ctx.store))
+
+"""
+Clears all indices. Fresh index will be created on next call to `index`.
+"""
+function clear_indices(ctx::Ctx)
+    for file in indices(ctx)
+        rm(file; force=true)
+    end
+    nothing
+end
+
+"""
+Returns a list of paths that have been indexed.
+"""
+function paths_indexed(ctx::Ctx)
+    paths = Set{String}()
+    cmd = Cmd([cindex, "-list"])
+    for idxpath in indices(ctx)
+        success, out, err = readcmd_with_index(ctx, cmd, idxpath)
+        if success
+            for (t,m) in out
+                push!(paths, strip(m))
+            end
+        else
+            error("error reading index $idxpath")
+        end
+    end
+    paths
+end
+
+"""
+Index paths by calling the index method. While indexing, ensure paths are sorted such that paths appearing later are not substrings of those earlier. Otherwise, the earlier indexed entries are erased (strange behavior of `cindex`).
+"""
+function index(ctx::Ctx, path::String)
+    cmd = Cmd([cindex, path])
+    success, out, err = readcmd_with_index(ctx, cmd, ctx.resolver(ctx,path))
+    success
+end
+
+function index(ctx::Ctx, paths::Vector{String})
+    idxpaths = Dict{String,Vector{String}}()
+    for path in paths
+        idxpath = ctx.resolver(ctx,path)
+        paths = get!(()->String[], idxpaths, idxpath)
+        push!(paths, path)
+    end
+    results = Bool[]
+    for (idxpath, paths) in idxpaths
+        cmd = Cmd(append!([cindex], paths))
+        success, out, err = readcmd_with_index(ctx, cmd, idxpath)
+        push!(results, success)
+    end
+    results
+end
+
+"""
+Search by calling the search method with a regex pattern to search for. Optionally pass the following parameters:
+- `ignorecase`: boolean, whether to ignore case during search (default false)
+- `pathfilter`: a regular expression string to restrict search only to matching paths
+
+The search method returns a vector of named tuples, each describing a match.
+- `file`: path that matched
+- `line`: line number therein that matched
+- `text`: text that matched
+"""
+function search(ctx::Ctx, pattern::String; ignorecase::Bool=false, pathfilter::Union{Nothing,String}=nothing)
+    cmdparts = [csearch]
+    if pathfilter !== nothing
+        push!(cmdparts, "-f")
+        push!(cmdparts, pathfilter)
+    end
+    ignorecase && push!(cmdparts, "-i")
+    push!(cmdparts, "-n")
+    push!(cmdparts, pattern)
+    cmd = Cmd(cmdparts)
+    results = Vector{NamedTuple{(:file,:line,:text),Tuple{String,Int,String}}}()
+    for idx in readdir(ctx.store)
+        idxpath = joinpath(ctx.store, idx)
+        success, out, err = readcmd_with_index(ctx, cmd, idxpath)
+        if success
+            for (t,s) in out
+                parts = split(s, ':'; limit=3)
+                push!(results, (file=String(parts[1]), line=parse(Int,parts[2]), text=String(parts[3])))
+            end
+        end
+    end
+    results
+end

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,0 +1,37 @@
+function handle_index(ctx::Ctx, req::Dict{String,Any})
+    if "path" in keys(req)
+        path = req["path"]
+        index(ctx, isa(path, Vector) ? index(ctx, convert(Vector{String}, path)) : path)
+    end
+    true
+end
+
+function handle_search(ctx::Ctx, req::Dict{String,Any})
+    ("pattern" in keys(req)) ? search(ctx, req["pattern"]; ignorecase=get(req, "ignorecase", false), pathfilter=get(req, "pathfilter", nothing)) : []
+end
+
+function read_req(req::HTTP.Request)
+    body = HTTP.payload(req)
+    isempty(body) ? nothing : JSON.parse(String(body))
+end
+
+function prep_router(ctx::Ctx, ops)
+    router = HTTP.Router()
+    (:index in ops) && HTTP.@register(router, "POST", "/index", (req)->handle_index(ctx,read_req(req)))
+    (:search in ops) && HTTP.@register(router, "POST", "/search", (req)->handle_search(ctx,read_req(req)))
+    router
+end
+
+function run_http(ctx::Ctx; host=ip"0.0.0.0", port=5555, ops=(:index, :search), kwargs...)
+    resp_headers = ["Content-Type" => "application/json; charset=utf-8", "Cache-Control" => "no-cache"]
+    router = prep_router(ctx, ops)
+    HTTP.serve(host, port; kwargs...) do req::HTTP.Request
+        resp = try
+            (success=true, data=HTTP.handle(router, req))
+        catch ex
+            @warn("exception processing req", req, ex)
+            (success=false, data="unknown error")
+        end
+        HTTP.Response(200, resp_headers; body=JSON.json(resp), request=req)
+    end
+end


### PR DESCRIPTION
A HTTP service with JSON interface can be brought up with the `run_http` method. Use optional parameter `ops` to sepcify the operations that should be exposed. Additional keywords, identical to what `HTTP.serve` would accept can also be passed to this method to enable other features e.g. SSL, port reuse.

```julia
julia> using GoogleCodeSearch
julia> ctx = Ctx();
julia> run_http(ctx; host=ip"0.0.0.0", port=5555, ops=(:index, :search))
```