### PR TITLE
add index manipulation methods to prune paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 julia:
   - 1.3
   - 1.4
+  - 1.5
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GoogleCodeSearch"
 uuid = "be5e5202-b427-58d6-b196-3d129152056c"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
@@ -17,7 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test"]
 
 [compat]
-julia = "1.3,1.4"
-HTTP = "0.8"
+julia = "1.3,1.4,1.5"
+HTTP = "0.8,0.9"
 JSON = "0.21"
 GoogleCodeSearch_jll = "1.2"

--- a/README.md
+++ b/README.md
@@ -61,3 +61,32 @@ julia> ctx = Ctx();
 
 julia> run_http(ctx; host=ip"0.0.0.0", port=5555, ops=(:index, :search))
 ```
+
+Also provides methods to read, manipulate and write index files directly from Julia:
+- `prune_paths!(idx, paths::Union{String,Vector{String}})`: Removes paths and files under the path from the index. Note that removing a path will also disable reindexing of that path in future by simply invoking `cindex` to reindex all paths.
+- `prune_files!(idx::Index, files::Union{String,Vector{String}})`: Removes individual files from the index. Path information is retained in the index and will get reindex in future by involing `cindex`.
+
+
+```julia
+julia> using GoogleCodeSearch
+
+julia> index_file = "/tmp/index";
+
+julia> idx = GoogleCodeSearch.Index();
+
+julia> open(index_file, "r") do inp
+           read(inp, idx)
+       end;
+
+julia> # delete all files under path and remove path from index
+
+julia> GoogleCodeSearch.prune_paths!(idx, "/tmp/jl_DmBJhH/data/path1");
+
+julia> # remove file from index
+
+julia> GoogleCodeSearch.prune_files!(idx, "/tmp/jl_DmBJhH/data/path22/file2");
+
+julia> open(index_file, "w") do out
+           write(out, idx)
+       end;
+```


### PR DESCRIPTION
This adds methods to prune paths from the index.
- `prune_paths!(idx, paths::Union{String,Vector{String}})`: Removes paths and files under the path from the index. Note that removing a path will also disable reindexing of that path in future by simply invoking `cindex` to reindex all paths.
- `prune_files!(idx::Index, files::Union{String,Vector{String}})`: Removes individual files from the index. Path information is retained in the index and will get reindex in future by involing `cindex`.