### PR TITLE
do maxresults check at a deeper level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
         version:
           - '1.3'
           - '1' # automatically expands to the latest stable 1.x release of Julia
-          - nightly
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GoogleCodeSearch"
 uuid = "be5e5202-b427-58d6-b196-3d129152056c"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,13 @@ function test_search(ctx::Ctx, datadir::String)
             @test isempty(res)
         end
     end
+
+    # test maxresults
+    for maxresults in (1, 2)
+        res = search(ctx, "Line2"; ignorecase=true, maxresults=maxresults)
+        @test length(res) <= 3  # 3 is the max we have in any split and 2 is the min in any split
+    end
+
     nothing
 end
 


### PR DESCRIPTION
Do the check for maxresults at a deeper level, to avoid getting swamped when there could be too many matches in a partition.