### PR TITLE
Support both JSON.jl 0.x and 1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,5 +19,5 @@ test = ["Test"]
 [compat]
 julia = "1.3"
 HTTP = "0.8,0.9,1,2"
-JSON = "0.21"
+JSON = "0.21, 1"
 GoogleCodeSearch_jll = "1.2"

--- a/src/server.jl
+++ b/src/server.jl
@@ -26,7 +26,10 @@ end
 
 function read_req(req::HTTP.Request)
     body = is_http_2 ? String(req.body) : String(HTTP.payload(req))
-    isempty(body) ? nothing : JSON.parse(body)
+    # `dicttype` keeps the parsed object a `Dict{String,Any}` across both
+    # JSON.jl 0.21 (default) and 1.x (which otherwise returns a `JSON.Object`),
+    # so the `handle_*` methods dispatch correctly under either version.
+    isempty(body) ? nothing : JSON.parse(body; dicttype=Dict{String,Any})
 end
 
 function prep_router(ctx::Ctx, ops)


### PR DESCRIPTION
## Summary

Makes the package compatible with both JSON.jl 0.x and 1.x.

JSON.jl 1.x's `JSON.parse` returns a `JSON.Object` rather than a `Dict{String,Any}`, which fails the `handle_index`/`handle_search` dispatch (both methods take `req::Dict{String,Any}`). This passes `dicttype=Dict{String,Any}` to `JSON.parse` — a keyword supported in both 0.21 and 1.x — so the parsed body keeps its concrete type, and widens the JSON compat bound to `"0.21, 1"`.

`JSON.json` output and the test-side string-key indexing were already compatible across both versions.

## Testing

Ran the full test suite against both versions in pinned environments:

| JSON.jl version | Result |
|---|---|
| 0.21.4 | ✅ 297/297 pass |
| 1.6.1  | ✅ 297/297 pass |

This exercises the live HTTP service test that round-trips JSON through `read_req` and `JSON.json`.